### PR TITLE
Simplifying some odd interpolation; passing reportName to getTestResultsMarkup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ jobs:
 
       - name: Create Status check based on postman results
         id: process-postman
-        uses: im-open/process-postman-test-results@v2.0.3
+        uses: im-open/process-postman-test-results@v2.0.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: ${{env.PACKAGE_JSON_DIR }}/${{ env.POSTMAN_RESULTS_NAME }}

--- a/dist/index.js
+++ b/dist/index.js
@@ -8908,14 +8908,14 @@ ${getBadge(jsonResults.stats.requests, 'Requests')}
 ${getBadge(jsonResults.stats.assertions, 'Assertions')}
 ${getTestTimes(jsonResults.timings)}
 ${getTestCounters(jsonResults)}
-${getTestResultsMarkup(jsonResults.failures)}
+${getTestResultsMarkup(jsonResults.failures, reportName2)}
   `;
     }
     function getBadge(stats, name) {
       const failedCount = stats.failed;
       const totalCount = stats.total;
       const passedCount = totalCount - failedCount;
-      const badgeCountText = failedCount > 0 ? `${`${failedCount}/${totalCount}`}` : `${`${passedCount}/${totalCount}`}`;
+      const badgeCountText = failedCount > 0 ? `${failedCount}/${totalCount}` : `${passedCount}/${totalCount}`;
       const badgeStatusText = failedCount > 0 ? 'FAILED' : 'PASSED';
       const badgeColor = failedCount > 0 ? 'red' : 'brightgreen';
       return `![Generic badge](https://img.shields.io/badge/${name}_${badgeCountText}-${badgeStatusText}-${badgeColor}.svg)`;

--- a/src/markup.js
+++ b/src/markup.js
@@ -10,7 +10,7 @@ ${getBadge(jsonResults.stats.requests, 'Requests')}
 ${getBadge(jsonResults.stats.assertions, 'Assertions')}
 ${getTestTimes(jsonResults.timings)}
 ${getTestCounters(jsonResults)}
-${getTestResultsMarkup(jsonResults.failures)}
+${getTestResultsMarkup(jsonResults.failures, reportName)}
   `;
 }
 
@@ -19,7 +19,7 @@ function getBadge(stats, name) {
   const totalCount = stats.total;
   const passedCount = totalCount - failedCount;
 
-  const badgeCountText = failedCount > 0 ? `${`${failedCount}/${totalCount}`}` : `${`${passedCount}/${totalCount}`}`;
+  const badgeCountText = failedCount > 0 ? `${failedCount}/${totalCount}` : `${passedCount}/${totalCount}`;
   const badgeStatusText = failedCount > 0 ? 'FAILED' : 'PASSED';
   const badgeColor = failedCount > 0 ? 'red' : 'brightgreen';
 


### PR DESCRIPTION
# Summary of PR changes

Just a couple of minor changes that will hopefully resolve `undefined` appearing in [Postman test results comments like this one](https://github.com/im-client/participant-guidance/pull/240#issuecomment-1065334442).

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
